### PR TITLE
Pre-commit hook fix

### DIFF
--- a/nix/pre-commit.nix
+++ b/nix/pre-commit.nix
@@ -1,17 +1,19 @@
-let 
-  pkgs = import (
-    fetchTarball "https://github.com/NixOS/nixpkgs/archive/69335c46c48a73f291d5c6f332fb9fe8b8e22b30.tar.gz"
-  ) {};
+let
+  pkgs = import
+    (
+      fetchTarball "https://github.com/NixOS/nixpkgs/archive/69335c46c48a73f291d5c6f332fb9fe8b8e22b30.tar.gz"
+    )
+    { };
   nix-pre-commit-hooks = import (
-    builtins.fetchTarball "https://github.com/cachix/pre-commit-hooks.nix/tarball/master"
+    fetchTarball "https://github.com/cachix/pre-commit-hooks.nix/archive/ebcbfe09d2bd6d15f68de3a0ebb1e4dcb5cd324b.tar.gz"
   );
 
 in
 {
   pre-commit-check = nix-pre-commit-hooks.run {
-     src = ../.;
-     
-     hooks = {
+    src = ../.;
+
+    hooks = {
       prettier.enable = true;
       statix.enable = true;
       black.enable = true;
@@ -20,52 +22,52 @@ in
       trailing-whitespace = {
         enable = true;
         entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/trailing-whitespace-fixer";
-        types = ["text"];
+        types = [ "text" ];
       };
       end-of-file-fixer = {
         enable = true;
         entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/end-of-file-fixer";
-        types = ["text"];
+        types = [ "text" ];
       };
       check-added-large-files = {
         enable = true;
         entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/check-added-large-files";
-        types = ["text"];
+        types = [ "text" ];
       };
       check-merge-conflict = {
         enable = true;
         entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/check-merge-conflict";
-        types = ["text"];
+        types = [ "text" ];
       };
       mixed-line-ending = {
         enable = true;
         entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/mixed-line-ending";
-        types = ["text"];
+        types = [ "text" ];
       };
       check-yaml = {
         enable = true;
         entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/check-yaml";
-        types = ["text"];
+        types = [ "text" ];
         files = "\\.yaml$";
       };
       check-xml = {
         enable = true;
         entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/check-xml";
-        types = ["text"];
+        types = [ "text" ];
         files = "\\.xml$";
-        };
+      };
       check-json = {
         enable = true;
         entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/check-json";
-        types = ["text"];
+        types = [ "text" ];
         files = "\\.json$";
       };
       protolint = {
         enable = true;
         entry = "${pkgs.protolint}/bin/protolint lint -fix";
-        types = ["text"];
+        types = [ "text" ];
         files = "\\.proto$";
       };
-     };
+    };
   };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -45,7 +45,7 @@ in
         packages.core-go
       ];
       shellHook = ''
-        ${(import ./pre-commit.nix).pre-commit-check.shellHook}
+        ${import (./pre-commit.nix).shellHook}
         export GICORE=${packages.core-go}/core.so
       '';
   }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -45,7 +45,7 @@ in
         packages.core-go
       ];
       shellHook = ''
-        ${import (./pre-commit.nix).shellHook}
+        ${(import ./pre-commit.nix).pre-commit-check.shellHook}
         export GICORE=${packages.core-go}/core.so
       '';
   }


### PR DESCRIPTION
Fixing the pre-commit hooks being loaded by the nix-shell command was simple enough. Unluckily, you've run into a bug in upstream [cachix/pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix) which no longer exposes pre-commit tools to non-flake projects. I've fixed that by fetching an earlier working version of cachix/pre-commit-hooks.nix. See this [issue](https://github.com/cachix/pre-commit-hooks.nix/issues/197) for more information.

As it is right now, the pre-commit hook is working, but you should probably keep an eye on upstream to see if they've fixed the bug so you can use the latest version.